### PR TITLE
feat(skills): add HackMD realtime CRUD v2

### DIFF
--- a/SKILLS/hackmd-realtime-crud/.gitignore
+++ b/SKILLS/hackmd-realtime-crud/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.hackmd-rt/
+coverage/
+*.log

--- a/SKILLS/hackmd-realtime-crud/LICENSE
+++ b/SKILLS/hackmd-realtime-crud/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DF-wu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SKILLS/hackmd-realtime-crud/README.md
+++ b/SKILLS/hackmd-realtime-crud/README.md
@@ -1,0 +1,90 @@
+# hackmd-realtime-cli
+
+`hackmd-rt` is an agent-friendly HackMD CLI that uses an authenticated browser
+session and HackMD's realtime operational-transform channel. It does not call
+the quota-limited public API and does not automate the editor DOM.
+
+Version 2.0 was verified against HackMD production on 2026-08-21. The realtime
+wire protocol is private and may change without notice, so every mutation waits
+for an OT acknowledgement and then reconnects to verify the complete Markdown.
+
+## Requirements
+
+- Node.js 22 or newer
+- A HackMD browser-cookie JSON export for authenticated/private notes
+
+The cookie store is a live credential. Keep it outside repositories and never
+print, copy, or attach it.
+
+## Install
+
+```bash
+npm install
+npm link
+```
+
+## Authentication
+
+Export cookies for `hackmd.io` as JSON with a browser extension, then import
+them into the private local store:
+
+```bash
+hackmd-rt auth import --cookie-file /absolute/cookies.json --clear --json
+hackmd-rt status --json
+```
+
+The default store is `${XDG_CONFIG_HOME:-~/.config}/hackmd-rt/cookies.json`
+with mode `0600`. `HACKMD_RT_COOKIES` or `--cookies` can override it.
+
+## Note workflows
+
+```bash
+hackmd-rt notes list --json
+hackmd-rt notes search keyword --json
+hackmd-rt notes get NOTE_ID_OR_URL --raw
+hackmd-rt notes create --file note.md --title "Title" --json
+hackmd-rt notes update NOTE_ID_OR_URL --file note.md --json
+hackmd-rt notes delete NOTE_ID_OR_URL --yes --json
+```
+
+Selectors accept an exact title, note ID, short ID, permalink, or HackMD URL.
+Duplicate exact titles fail instead of selecting arbitrarily. Search uses the
+overview metadata and excerpt, not the complete text of every note.
+
+Create and update consume complete Markdown from a file or stdin. Update sends
+a minimal single-span OT replacement from the current realtime snapshot,
+waits for `ack`, reconnects, and compares the full Markdown. A concurrent edit
+is preserved by HackMD OT; if it changes the requested final document, the CLI
+returns exit code 4 instead of overwriting it again.
+
+If a connection drops after a mutation may have reached HackMD, the CLI
+reconnects before deciding the result. Exact readback is reported as verified
+success; a mismatch or failed reconciliation returns exit code 5 and identifies
+the note whose outcome must be checked before retrying. Create and delete use
+the same explicit uncertain-outcome classification for partial failures.
+
+## Protocol
+
+The current editor advertises its registration endpoint in the
+`realtime-register-serverurl` meta tag. The CLI resolves that endpoint, opens a
+cookie-authenticated Socket.IO connection with `query.noteId`, and uses the
+public [`hackmdio/ot.js`](https://github.com/hackmdio/ot.js) operation format:
+
+- `doc { str, revision, clients }` initializes a snapshot.
+- `operation(revision, ops, null)` submits a mutation.
+- `ack(nextRevision)` confirms acceptance by the realtime server.
+
+Operation offsets are JavaScript UTF-16 code units. The CLI uses HackMD's OT
+implementation directly, including for emoji and supplementary characters.
+
+An acknowledgement alone is not treated as durable success. Reconnection and
+exact readback are mandatory. Handshake or payload drift fails closed.
+
+## Development
+
+```bash
+npm run check
+```
+
+Production smoke tests require an explicit disposable note and are not run by
+the unit test suite.

--- a/SKILLS/hackmd-realtime-crud/SKILL.md
+++ b/SKILLS/hackmd-realtime-crud/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: hackmd-realtime-crud
+description: Manage HackMD notes through authenticated realtime OT without API credit or browser editor automation.
+---
+
+# HackMD Realtime CRUD
+
+Use the installed `hackmd-rt` binary. Run `hackmd-rt --help` before choosing
+flags. This tool uses HackMD's private realtime protocol and a browser-cookie
+session; it never calls `api.hackmd.io/v1`.
+
+Check authentication with `hackmd-rt status --json`. When authentication is
+missing, ask the user to export HackMD cookies to a local JSON file, then run:
+
+```bash
+hackmd-rt auth import --cookie-file /absolute/export.json --clear --json
+```
+
+Never inspect, print, attach, or commit the cookie export or cookie store.
+
+Prefer IDs or URLs as selectors. Exact titles are accepted, but duplicate
+titles fail. `notes search` covers overview title, tags, and excerpt only.
+
+Read exact Markdown:
+
+```bash
+hackmd-rt notes get NOTE_ID_OR_URL --raw
+```
+
+For create or update, stage the complete UTF-8 Markdown in a temporary file or
+pipe it through stdin:
+
+```bash
+hackmd-rt notes create --file /tmp/note.md --title "Title" --json
+hackmd-rt notes update NOTE_ID_OR_URL --file /tmp/note.md --json
+```
+
+Mutations are successful only after realtime acknowledgement and an independent
+reconnection reproduces the exact Markdown. Exit code 4 means a concurrent edit
+was preserved and the requested exact final content was not reached; reconcile
+the latest note instead of retrying blindly.
+
+Exit code 5 means the server may have accepted a create, update, or delete but
+the final state could not be established. Read the identified note or check
+HackMD Trash before retrying; never replay an uncertain mutation blindly.
+
+Delete only when the current user request explicitly identifies the note and
+authorizes deletion. Then pass `--yes`:
+
+```bash
+hackmd-rt notes delete NOTE_ID_OR_URL --yes --json
+```
+
+If the handshake schema changes, stop. Do not fall back to guessed events or
+raw undocumented endpoints for mutation.

--- a/SKILLS/hackmd-realtime-crud/bin/hackmd-rt.js
+++ b/SKILLS/hackmd-realtime-crud/bin/hackmd-rt.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { main } from '../src/cli.js';
+
+main(process.argv.slice(2)).catch((error) => {
+  const exitCode = Number.isInteger(error.exitCode) ? error.exitCode : 1;
+  process.stderr.write(`hackmd-rt: ${error.message}\n`);
+  process.exitCode = exitCode;
+});

--- a/SKILLS/hackmd-realtime-crud/package-lock.json
+++ b/SKILLS/hackmd-realtime-crud/package-lock.json
@@ -1,0 +1,170 @@
+{
+  "name": "@df-wu/hackmd-realtime-cli",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@df-wu/hackmd-realtime-cli",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hackmd/ot": "0.1.0",
+        "socket.io-client": "4.8.1"
+      },
+      "bin": {
+        "hackmd-rt": "bin/hackmd-rt.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@hackmd/ot": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@hackmd/ot/-/ot-0.1.0.tgz",
+      "integrity": "sha512-JzspgDVXSYb+MlIsO4MEs4xcJslOhu+KMENa9KxmKesCQB80JVWu6zq9dx/cB+ga4//d6dshmBaHfkqx/GlBIw=="
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/SKILLS/hackmd-realtime-crud/package.json
+++ b/SKILLS/hackmd-realtime-crud/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@df-wu/hackmd-realtime-cli",
+  "version": "2.0.0",
+  "description": "Agent-friendly HackMD CLI using authenticated realtime OT instead of browser automation",
+  "type": "module",
+  "bin": {
+    "hackmd-rt": "bin/hackmd-rt.js"
+  },
+  "scripts": {
+    "check": "npm run lint && npm test",
+    "lint": "node --check bin/hackmd-rt.js && node --check src/*.js && node --check test/*.js",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@hackmd/ot": "0.1.0",
+    "socket.io-client": "4.8.1"
+  },
+  "license": "MIT",
+  "private": true
+}

--- a/SKILLS/hackmd-realtime-crud/src/cli.js
+++ b/SKILLS/hackmd-realtime-crud/src/cli.js
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { CookieJar, defaultCookiePath, importCookies } from './cookies.js';
+import { CliError } from './errors.js';
+import { fetchOverview } from './http.js';
+import { createNote, deleteNote, getNote, listNotes, searchNotes, updateNote } from './notes.js';
+
+const HELP = `hackmd-rt 2.0 - HackMD realtime OT CLI
+
+Usage:
+  hackmd-rt status [--json]
+  hackmd-rt auth import --cookie-file PATH [--clear] [--json]
+  hackmd-rt notes list [--json]
+  hackmd-rt notes search QUERY [--limit N] [--json]
+  hackmd-rt notes get SELECTOR [--raw|--json]
+  hackmd-rt notes create --file PATH [--title TITLE] [--json]
+  hackmd-rt notes update SELECTOR --file PATH [--json]
+  hackmd-rt notes delete SELECTOR --yes [--json]
+
+Global options:
+  --cookies PATH   Cookie store (default: ${defaultCookiePath()})
+  --timeout MS     Realtime handshake/write timeout (default: 20000)
+`;
+
+export function parseCommandLine(argv) {
+  const options = {};
+  const positionals = [];
+  const booleans = new Set(['json', 'raw', 'clear', 'yes', 'help', 'version']);
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (!value.startsWith('--')) {
+      positionals.push(value);
+      continue;
+    }
+    const separator = value.indexOf('=');
+    const name = value.slice(2, separator < 0 ? undefined : separator);
+    if (booleans.has(name)) {
+      options[name] = separator < 0 || value.slice(separator + 1) !== 'false';
+      continue;
+    }
+    const optionValue = separator < 0 ? argv[++index] : value.slice(separator + 1);
+    if (optionValue === undefined || optionValue.startsWith('--')) throw new CliError(`--${name} requires a value.`);
+    options[name] = optionValue;
+  }
+  return { options, positionals };
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new CliError(`--${name} must be a positive integer.`);
+  return parsed;
+}
+
+export function validateInvocation(positionals, options) {
+  const [group, action, ...rest] = positionals;
+  const command = group === 'status' ? 'status' : `${group || ''} ${action || ''}`.trim();
+  const allowedByCommand = {
+    status: ['cookies', 'json'],
+    'auth import': ['cookie-file', 'clear', 'cookies', 'json'],
+    'notes list': ['cookies', 'json'],
+    'notes search': ['cookies', 'json', 'limit'],
+    'notes get': ['cookies', 'json', 'raw', 'timeout'],
+    'notes create': ['cookies', 'file', 'json', 'timeout', 'title'],
+    'notes update': ['cookies', 'file', 'json', 'timeout'],
+    'notes delete': ['cookies', 'json', 'timeout', 'yes']
+  };
+  const globallyAllowed = new Set(['help', 'version']);
+  const allowed = allowedByCommand[command];
+  if (allowed) {
+    const commandAllowed = new Set([...allowed, ...globallyAllowed]);
+    const unknown = Object.keys(options).find((name) => !commandAllowed.has(name));
+    if (unknown) throw new CliError(`Unknown option for ${command}: --${unknown}.`);
+  }
+  if (options.raw && options.json) throw new CliError('--raw and --json cannot be used together.');
+  if (options.timeout !== undefined) positiveInteger(options.timeout, 'timeout');
+  if (options.limit !== undefined) positiveInteger(options.limit, 'limit');
+
+  if (command === 'status' || command === 'notes list' || command === 'notes create') {
+    if (rest.length > 0) throw new CliError(`${command} does not accept positional arguments.`);
+  } else if (command === 'auth import') {
+    if (rest.length > 0) throw new CliError('auth import does not accept positional arguments.');
+  } else if (command === 'notes get' || command === 'notes update' || command === 'notes delete') {
+    if (rest.length !== 1) throw new CliError(`${command} requires exactly one selector.`);
+  } else if (command === 'notes search' && rest.length === 0) {
+    throw new CliError('notes search requires a query.');
+  }
+}
+
+async function markdownInput(file) {
+  if (!file) throw new CliError('Provide complete Markdown with --file PATH or --file -.');
+  if (file === '-') {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+    return Buffer.concat(chunks).toString('utf8');
+  }
+  try {
+    return await fs.promises.readFile(path.resolve(file), 'utf8');
+  } catch (error) {
+    throw new CliError(`Could not read Markdown file: ${error.message}`);
+  }
+}
+
+function output(value, options) {
+  if (options.raw) {
+    process.stdout.write(value.content);
+    if (value.content && !value.content.endsWith('\n')) process.stdout.write('\n');
+  } else if (options.json) {
+    console.log(JSON.stringify(value, null, 2));
+  } else if (Array.isArray(value)) {
+    for (const item of value) console.log(`${item.title}\t${item.shortId || item.id}\t${item.workspace}`);
+  } else {
+    console.log(JSON.stringify(value, null, 2));
+  }
+}
+
+export async function main(argv) {
+  const { options, positionals } = parseCommandLine(argv);
+  if (options.version) {
+    console.log('2.0.0');
+    return;
+  }
+  if (options.help || positionals.length === 0) {
+    process.stdout.write(HELP);
+    return;
+  }
+  validateInvocation(positionals, options);
+  const cookies = path.resolve(options.cookies || defaultCookiePath());
+  const timeoutMs = Number(options.timeout || 20_000);
+  if (timeoutMs < 1_000) throw new CliError('--timeout must be at least 1000 ms.');
+
+  const [group, action, ...rest] = positionals;
+  if (group === 'auth' && action === 'import') {
+    if (!options['cookie-file']) throw new CliError('auth import requires --cookie-file PATH.');
+    output(await importCookies(options['cookie-file'], cookies, options.clear), options);
+    return;
+  }
+
+  const jar = await CookieJar.load(cookies);
+  if (group === 'status') {
+    const notes = await fetchOverview(jar);
+    await jar.save(cookies);
+    output({ authenticated: true, notes: notes.length, cookies }, options);
+    return;
+  }
+  if (group !== 'notes') throw new CliError(`Unknown command: ${positionals.join(' ')}`);
+
+  let result;
+  if (action === 'list') result = await listNotes(jar);
+  else if (action === 'search') result = searchNotes(await fetchOverview(jar), rest.join(' '), Number(options.limit || 20));
+  else if (action === 'get') {
+    if (!rest[0]) throw new CliError('notes get requires a selector.');
+    result = await getNote(jar, rest[0], timeoutMs);
+  } else if (action === 'create') {
+    result = await createNote(jar, await markdownInput(options.file), options.title || '', timeoutMs);
+  } else if (action === 'update') {
+    if (!rest[0]) throw new CliError('notes update requires a selector.');
+    result = await updateNote(jar, rest[0], await markdownInput(options.file), timeoutMs);
+  } else if (action === 'delete') {
+    if (!rest[0]) throw new CliError('notes delete requires a selector.');
+    if (!options.yes) throw new CliError('Refusing to delete without --yes.', 2);
+    result = await deleteNote(jar, rest[0], timeoutMs);
+  } else throw new CliError(`Unknown notes command: ${action || ''}`);
+
+  await jar.save(cookies);
+  output(result, options);
+}

--- a/SKILLS/hackmd-realtime-crud/src/cookies.js
+++ b/SKILLS/hackmd-realtime-crud/src/cookies.js
@@ -1,0 +1,187 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CliError } from './errors.js';
+
+export function defaultCookiePath() {
+  if (process.env.HACKMD_RT_COOKIES) return path.resolve(process.env.HACKMD_RT_COOKIES);
+  const root = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  return path.join(root, 'hackmd-rt', 'cookies.json');
+}
+
+function normalizedDomain(value) {
+  return String(value || '').trim().replace(/^\./, '').toLowerCase();
+}
+
+function domainMatches(cookie, hostname) {
+  return cookie.hostOnly
+    ? hostname === cookie.domain
+    : hostname === cookie.domain || hostname.endsWith(`.${cookie.domain}`);
+}
+
+function pathMatches(cookiePath, requestPath) {
+  const base = cookiePath || '/';
+  return requestPath === base
+    || requestPath.startsWith(base.endsWith('/') ? base : `${base}/`);
+}
+
+function normalizedSameSite(value) {
+  const sameSite = String(value || '').toLowerCase().replace(/[ _-]/g, '');
+  if (sameSite === 'strict') return 'Strict';
+  if (sameSite === 'none' || sameSite === 'norestriction') return 'None';
+  return 'Lax';
+}
+
+function booleanValue(value) {
+  if (typeof value === 'boolean') return value;
+  return /^(1|true|yes)$/i.test(String(value || ''));
+}
+
+function first(row, ...keys) {
+  for (const key of keys) {
+    if (row?.[key] !== undefined && row[key] !== null) return row[key];
+  }
+  return undefined;
+}
+
+export function normalizeCookieExport(value, now = Date.now()) {
+  const rows = Array.isArray(value) ? value : value?.cookies;
+  if (!Array.isArray(rows)) throw new CliError('Cookie export must be an array or {"cookies": [...]} object.');
+
+  const cookies = [];
+  let skipped = 0;
+  for (const row of rows) {
+    const name = String(first(row, 'name', 'Name raw') || '').trim();
+    const rawDomain = String(first(row, 'domain', 'host', 'Host raw') || '').trim();
+    const domain = normalizedDomain(rawDomain);
+    const rawExpires = Number(first(row, 'expires', 'expirationDate', 'Expires raw'));
+    const expires = Number.isFinite(rawExpires) && rawExpires > 0
+      ? (rawExpires > 1e12 ? rawExpires : rawExpires * 1000)
+      : null;
+    if (!name || domain !== 'hackmd.io' || (expires !== null && expires <= now)) {
+      skipped += 1;
+      continue;
+    }
+    cookies.push({
+      name,
+      value: String(first(row, 'value', 'Content raw') ?? ''),
+      domain,
+      hostOnly: row.hostOnly === undefined ? !rawDomain.startsWith('.') : booleanValue(row.hostOnly),
+      path: String(first(row, 'path', 'Path raw') || '/'),
+      expires,
+      httpOnly: booleanValue(first(row, 'httpOnly', 'HTTP only raw')),
+      secure: booleanValue(first(row, 'secure', 'Send for raw')),
+      sameSite: normalizedSameSite(first(row, 'sameSite', 'SameSite raw'))
+    });
+  }
+  return { cookies, skipped };
+}
+
+function splitSetCookie(header) {
+  if (!header) return [];
+  return header.split(/,(?=\s*[^;,=]+=[^;,]*)/g);
+}
+
+function parseSetCookie(header, requestUrl) {
+  const parts = header.split(';').map((part) => part.trim());
+  const separator = parts[0]?.indexOf('=') ?? -1;
+  if (separator <= 0) return null;
+  const url = new URL(requestUrl);
+  const cookie = {
+    name: parts[0].slice(0, separator),
+    value: parts[0].slice(separator + 1),
+    domain: url.hostname,
+    hostOnly: true,
+    path: '/',
+    expires: null,
+    httpOnly: false,
+    secure: false,
+    sameSite: 'Lax'
+  };
+  for (const attribute of parts.slice(1)) {
+    const index = attribute.indexOf('=');
+    const key = (index < 0 ? attribute : attribute.slice(0, index)).toLowerCase();
+    const value = index < 0 ? '' : attribute.slice(index + 1);
+    if (key === 'domain') {
+      cookie.domain = normalizedDomain(value);
+      cookie.hostOnly = false;
+    }
+    else if (key === 'path') cookie.path = value || '/';
+    else if (key === 'expires') cookie.expires = Date.parse(value) || null;
+    else if (key === 'max-age') cookie.expires = Date.now() + Number(value) * 1000;
+    else if (key === 'httponly') cookie.httpOnly = true;
+    else if (key === 'secure') cookie.secure = true;
+    else if (key === 'samesite') cookie.sameSite = normalizedSameSite(value);
+  }
+  return cookie;
+}
+
+export class CookieJar {
+  constructor(cookies = []) {
+    this.cookies = normalizeCookieExport(cookies).cookies;
+  }
+
+  static async load(file = defaultCookiePath()) {
+    try {
+      const parsed = JSON.parse(await fs.promises.readFile(file, 'utf8'));
+      return new CookieJar(parsed);
+    } catch (error) {
+      if (error.code === 'ENOENT') return new CookieJar();
+      throw new CliError(`Could not read cookie store ${file}: ${error.message}`);
+    }
+  }
+
+  header(url, now = Date.now()) {
+    const target = new URL(url);
+    return this.cookies
+      .filter((cookie) => domainMatches(cookie, target.hostname))
+      .filter((cookie) => pathMatches(cookie.path, target.pathname))
+      .filter((cookie) => cookie.expires === null || cookie.expires > now)
+      .filter((cookie) => !cookie.secure || target.protocol === 'https:')
+      .sort((left, right) => (right.path || '/').length - (left.path || '/').length)
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join('; ');
+  }
+
+  absorb(headers, requestUrl) {
+    const values = typeof headers.getSetCookie === 'function'
+      ? headers.getSetCookie()
+      : splitSetCookie(headers.get('set-cookie'));
+    for (const value of values) {
+      const incoming = parseSetCookie(value, requestUrl);
+      if (!incoming || incoming.domain !== 'hackmd.io') continue;
+      this.cookies = this.cookies.filter((cookie) => !(
+        cookie.name === incoming.name && cookie.domain === incoming.domain && cookie.path === incoming.path
+      ));
+      if (incoming.expires === null || incoming.expires > Date.now()) this.cookies.push(incoming);
+    }
+  }
+
+  async save(file = defaultCookiePath()) {
+    await fs.promises.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+    const temporary = `${file}.${process.pid}.tmp`;
+    await fs.promises.writeFile(temporary, `${JSON.stringify({ cookies: this.cookies }, null, 2)}\n`, { mode: 0o600 });
+    await fs.promises.rename(temporary, file);
+    await fs.promises.chmod(file, 0o600);
+  }
+}
+
+export async function importCookies(source, destination = defaultCookiePath(), clear = false) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await fs.promises.readFile(path.resolve(source), 'utf8'));
+  } catch (error) {
+    throw new CliError(`Could not read cookie export: ${error.message}`);
+  }
+  const imported = normalizeCookieExport(parsed);
+  const jar = clear ? new CookieJar() : await CookieJar.load(destination);
+  for (const cookie of imported.cookies) {
+    jar.cookies = jar.cookies.filter((current) => !(
+      current.name === cookie.name && current.domain === cookie.domain && current.path === cookie.path
+    ));
+    jar.cookies.push(cookie);
+  }
+  await jar.save(destination);
+  return { imported: imported.cookies.length, skipped: imported.skipped, path: destination };
+}

--- a/SKILLS/hackmd-realtime-crud/src/errors.js
+++ b/SKILLS/hackmd-realtime-crud/src/errors.js
@@ -1,0 +1,8 @@
+export class CliError extends Error {
+  constructor(message, exitCode = 1, details) {
+    super(message);
+    this.name = 'CliError';
+    this.exitCode = exitCode;
+    if (details !== undefined) this.details = details;
+  }
+}

--- a/SKILLS/hackmd-realtime-crud/src/http.js
+++ b/SKILLS/hackmd-realtime-crud/src/http.js
@@ -1,0 +1,93 @@
+import { CliError } from './errors.js';
+
+export const BASE_URL = 'https://hackmd.io';
+
+export async function request(jar, input, options = {}, redirects = 5) {
+  const url = new URL(input, BASE_URL);
+  if (url.origin !== BASE_URL) throw new CliError(`Refusing request outside ${BASE_URL}.`);
+  const headers = new Headers(options.headers);
+  const cookie = jar.header(url);
+  if (cookie) headers.set('Cookie', cookie);
+  headers.set('Accept', headers.get('Accept') || 'application/json');
+  headers.set('User-Agent', headers.get('User-Agent') || 'hackmd-rt/2.0');
+  const response = await fetch(url, { ...options, headers, redirect: 'manual' });
+  jar.absorb(response.headers, url);
+  if (response.status >= 300 && response.status < 400 && redirects > 0) {
+    const location = response.headers.get('location');
+    if (!location) return response;
+    const next = new URL(location, url);
+    if (next.origin !== BASE_URL) throw new CliError(`Refusing redirect outside ${BASE_URL}.`);
+    return request(jar, next, { method: 'GET', headers: { Accept: headers.get('Accept') } }, redirects - 1);
+  }
+  return response;
+}
+
+export async function fetchOverview(jar) {
+  const response = await request(jar, `/api/overview?v=${Date.now()}`);
+  const contentType = response.headers.get('content-type') || '';
+  if (!response.ok || !contentType.includes('application/json')) {
+    throw new CliError('HackMD session is not authenticated or the overview response changed.', 3);
+  }
+  const value = await response.json();
+  if (!Array.isArray(value)) throw new CliError('HackMD overview did not return a note array.', 3);
+  return value;
+}
+
+export async function realtimeServer(jar, noteId) {
+  const noteResponse = await request(jar, `/${encodeURIComponent(noteId)}`, { headers: { Accept: 'text/html' } });
+  if (!noteResponse.ok) throw new CliError(`Could not open note ${noteId}: HTTP ${noteResponse.status}.`);
+  const html = await noteResponse.text();
+  const register = html.match(/<meta\s+name=["']realtime-register-serverurl["']\s+content=["']([^"']+)/i)?.[1]
+    || html.match(/<meta\s+content=["']([^"']+)["']\s+name=["']realtime-register-serverurl["']/i)?.[1];
+  if (!register) throw new CliError('HackMD editor no longer advertises a realtime registration endpoint.');
+  const endpoint = new URL(`${register.replace(/\/$/, '')}/realtime`);
+  if (endpoint.origin !== BASE_URL) throw new CliError('Refusing an unexpected realtime registration origin.');
+  endpoint.searchParams.set('noteId', noteId);
+  const response = await request(jar, endpoint);
+  if (!response.ok) throw new CliError(`Realtime registration failed: HTTP ${response.status}.`);
+  const data = await response.json();
+  const server = new URL(data.url);
+  if (server.protocol !== 'https:') throw new CliError('Realtime registration returned a non-HTTPS server.');
+  return { server, editorHtml: html };
+}
+
+export function csrfFromNewPage(html) {
+  const token = html.match(/xhr\.send\('_csrf=([^']+)'\)/)?.[1];
+  if (!token) throw new CliError('HackMD new-note page no longer exposes the expected CSRF submission.');
+  return token;
+}
+
+export async function createEmptyNote(jar, title = '') {
+  const page = await request(jar, '/new', { headers: { Accept: 'text/html' } });
+  if (!page.ok) throw new CliError(`Could not prepare a new note: HTTP ${page.status}.`);
+  const csrf = csrfFromNewPage(await page.text());
+  const url = new URL('/new', BASE_URL);
+  url.searchParams.set('title', title);
+  url.searchParams.set('alias', 'false');
+  url.searchParams.set('sync', '');
+  url.searchParams.set('type', '');
+  let response;
+  try {
+    response = await request(jar, url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'text/html' },
+      body: new URLSearchParams({ _csrf: csrf }).toString()
+    }, 0);
+  } catch (error) {
+    throw new CliError(
+      `The create request outcome is unknown (${error.message}). Inspect recent HackMD notes before retrying.`,
+      5,
+      { mayHaveCreated: true }
+    );
+  }
+  if (response.status < 300 || response.status >= 400) {
+    throw new CliError(`HackMD did not create a note: HTTP ${response.status}.`);
+  }
+  const location = response.headers.get('location');
+  if (!location) throw new CliError('HackMD created a note without returning its URL.');
+  const noteUrl = new URL(location, BASE_URL);
+  if (noteUrl.origin !== BASE_URL) throw new CliError('HackMD returned an unexpected note origin.');
+  const noteId = decodeURIComponent(noteUrl.pathname.split('/').filter(Boolean).at(-1) || '');
+  if (!noteId) throw new CliError('Could not determine the new note ID.');
+  return { noteId, url: noteUrl.toString() };
+}

--- a/SKILLS/hackmd-realtime-crud/src/notes.js
+++ b/SKILLS/hackmd-realtime-crud/src/notes.js
@@ -1,0 +1,199 @@
+import { CliError } from './errors.js';
+import { BASE_URL, createEmptyNote, fetchOverview } from './http.js';
+import { replacementOperation } from './ot.js';
+import { readRealtime, writeRealtime } from './realtime.js';
+
+export function noteMetadata(note) {
+  return {
+    id: note.id ?? null,
+    shortId: note.shortId ?? null,
+    title: note.title || 'Untitled',
+    tags: Array.isArray(note.tags) ? note.tags : [],
+    lastchangeAt: note.lastchangeAt ?? null,
+    createdAt: note.createdAt ?? null,
+    workspace: note.teamname || 'personal',
+    teampath: note.teampath || null,
+    permalink: note.permalink || null,
+    isOwner: Boolean(note.isOwner),
+    url: note.shortId ? `${BASE_URL}/${note.shortId}` : null
+  };
+}
+
+export function selectorFromInput(input) {
+  const raw = String(input || '').trim();
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    if (url.origin !== BASE_URL) return raw;
+    return decodeURIComponent(url.pathname.split('/').filter(Boolean).at(-1) || raw);
+  } catch {
+    return raw;
+  }
+}
+
+export function resolveNote(notes, input) {
+  const raw = String(input || '').trim();
+  const selector = selectorFromInput(raw);
+  const matches = notes.filter((note) => [
+    note.id,
+    note.shortId,
+    note.permalink,
+    note.title,
+    note.shortId ? `${BASE_URL}/${note.shortId}` : null
+  ].filter(Boolean).some((candidate) => String(candidate) === selector || String(candidate) === raw));
+  if (matches.length === 0) throw new CliError(`Note not found: ${raw}`, 2);
+  if (matches.length > 1) throw new CliError('Ambiguous note selector. Use a note ID or URL.', 2);
+  return matches[0];
+}
+
+export function searchNotes(notes, query, limit = 20) {
+  const needle = String(query || '').toLocaleLowerCase();
+  if (!needle) throw new CliError('Search query cannot be empty.');
+  return notes.filter((note) => {
+    const title = String(note.title || '').toLocaleLowerCase();
+    const excerpt = String(note.content || '').toLocaleLowerCase();
+    const tags = Array.isArray(note.tags) ? note.tags.map((tag) => String(tag).toLocaleLowerCase()) : [];
+    return title.includes(needle) || excerpt.includes(needle) || tags.some((tag) => tag.includes(needle));
+  }).slice(0, limit).map(noteMetadata);
+}
+
+async function resolveFromOverview(jar, selector) {
+  const notes = await fetchOverview(jar);
+  return { note: resolveNote(notes, selector), notes };
+}
+
+export async function listNotes(jar) {
+  return (await fetchOverview(jar)).map(noteMetadata);
+}
+
+export async function getNote(jar, selector, timeoutMs) {
+  let note;
+  let noteId = selectorFromInput(selector);
+  try {
+    note = (await resolveFromOverview(jar, selector)).note;
+    noteId = note.shortId || note.id;
+  } catch (error) {
+    if (error.exitCode !== 3 && !/^[-_A-Za-z0-9]+$/.test(noteId)) throw error;
+  }
+  const snapshot = await readRealtime(jar, noteId, timeoutMs);
+  return { ...(note ? noteMetadata(note) : { shortId: noteId, url: `${BASE_URL}/${noteId}` }), ...snapshot };
+}
+
+export async function createNote(jar, content, title, timeoutMs) {
+  const created = await createEmptyNote(jar, title);
+  const heading = title ? `# ${title.trim()}` : '';
+  const firstLine = content.replace(/^\uFEFF/, '').split(/\r?\n/, 1)[0].trim();
+  const completeContent = heading && firstLine !== heading ? `${heading}\n\n${content}` : content;
+  try {
+    const result = await updateById(jar, created.noteId, completeContent, timeoutMs);
+    return { ...created, ...result };
+  } catch (error) {
+    throw new CliError(
+      `Created ${created.url}, but content initialization did not complete: ${error.message}`,
+      error.exitCode || 5,
+      { ...error.details, noteId: created.noteId, url: created.url, created: true }
+    );
+  }
+}
+
+export async function updateById(
+  jar,
+  noteId,
+  content,
+  timeoutMs,
+  realtime = { read: readRealtime, write: writeRealtime }
+) {
+  let write;
+  try {
+    write = await realtime.write(jar, noteId, (before) => replacementOperation(before, content), timeoutMs);
+  } catch (error) {
+    if (!error.details?.mayHaveApplied) throw error;
+    const reconciled = await realtime.read(jar, noteId, timeoutMs).catch((readError) => {
+      throw new CliError(
+        `Update outcome is unknown for ${BASE_URL}/${noteId}; acknowledgement and reconciliation both failed (${readError.message}).`,
+        5,
+        { noteId, mayHaveApplied: true }
+      );
+    });
+    if (reconciled.content === content) {
+      return {
+        changed: true,
+        concurrent: false,
+        revision: reconciled.revision,
+        verified: true,
+        acknowledgementLost: true
+      };
+    }
+    throw new CliError(
+      `Update outcome is uncertain for ${BASE_URL}/${noteId}; the current content does not match the request. Reconcile before retrying.`,
+      5,
+      { noteId, mayHaveApplied: true, revision: reconciled.revision }
+    );
+  }
+  const verified = await realtime.read(jar, noteId, timeoutMs);
+  if (verified.content !== content) {
+    throw new CliError(
+      'The note changed during the update; realtime OT preserved the concurrent edit, so exact verification failed.',
+      4,
+      { noteId, revision: verified.revision, concurrent: write.concurrent }
+    );
+  }
+  return { changed: write.changed, concurrent: write.concurrent, revision: verified.revision, verified: true };
+}
+
+export async function updateNote(jar, selector, content, timeoutMs) {
+  let note;
+  let noteId = selectorFromInput(selector);
+  try {
+    note = (await resolveFromOverview(jar, selector)).note;
+    noteId = note.shortId || note.id;
+  } catch (error) {
+    if (error.exitCode !== 3 && !/^[-_A-Za-z0-9]+$/.test(noteId)) throw error;
+  }
+  const result = await updateById(jar, noteId, content, timeoutMs);
+  return { ...(note ? noteMetadata(note) : { shortId: noteId, url: `${BASE_URL}/${noteId}` }), ...result };
+}
+
+export async function deleteNote(jar, selector, timeoutMs) {
+  const { note } = await resolveFromOverview(jar, selector);
+  const noteId = note.shortId || note.id;
+  const connection = await (await import('./realtime.js')).connectRealtime(jar, noteId, timeoutMs);
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      connection.socket.close();
+      resolve();
+    }, Math.min(timeoutMs, 2_000));
+    connection.socket.once('disconnect', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    connection.socket.once('info', (info) => {
+      clearTimeout(timer);
+      connection.socket.close();
+      reject(new CliError(`HackMD rejected the delete request (code ${info?.code || 'unknown'}).`, 3));
+    });
+    connection.socket.emit('delete');
+  });
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let notes;
+    try {
+      notes = await fetchOverview(jar);
+    } catch (error) {
+      throw new CliError(
+        `Delete outcome is unknown for ${BASE_URL}/${noteId}; verification failed (${error.message}). Check HackMD Trash before retrying.`,
+        5,
+        { noteId, mayHaveDeleted: true }
+      );
+    }
+    if (!notes.some((candidate) => candidate.shortId === noteId || candidate.id === noteId)) {
+      return { ...noteMetadata(note), deleted: true, verified: true, recovery: 'HackMD Trash' };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 750));
+  }
+  throw new CliError(
+    `The note still appears active after the delete request: ${BASE_URL}/${noteId}.`,
+    5,
+    { noteId, mayHaveDeleted: true }
+  );
+}

--- a/SKILLS/hackmd-realtime-crud/src/ot.js
+++ b/SKILLS/hackmd-realtime-crud/src/ot.js
@@ -1,0 +1,31 @@
+import ot from '@hackmd/ot';
+
+const { TextOperation } = ot;
+
+export function replacementOperation(before, after) {
+  let prefix = 0;
+  const maximumPrefix = Math.min(before.length, after.length);
+  while (prefix < maximumPrefix && before[prefix] === after[prefix]) prefix += 1;
+
+  let suffix = 0;
+  const maximumSuffix = Math.min(before.length - prefix, after.length - prefix);
+  while (suffix < maximumSuffix && before[before.length - 1 - suffix] === after[after.length - 1 - suffix]) suffix += 1;
+
+  const removed = before.length - prefix - suffix;
+  const inserted = after.slice(prefix, after.length - suffix);
+  const operation = new TextOperation();
+  operation.retain(prefix);
+  operation.insert(inserted);
+  operation.delete(removed);
+  operation.retain(suffix);
+  return operation;
+}
+
+export function applyOperation(content, json) {
+  return TextOperation.fromJSON(json).apply(content);
+}
+
+export function transformOperations(left, right) {
+  return TextOperation.transform(TextOperation.fromJSON(left), TextOperation.fromJSON(right))
+    .map((operation) => operation.toJSON());
+}

--- a/SKILLS/hackmd-realtime-crud/src/realtime.js
+++ b/SKILLS/hackmd-realtime-crud/src/realtime.js
@@ -1,0 +1,119 @@
+import { io } from 'socket.io-client';
+
+import { CliError } from './errors.js';
+import { BASE_URL, realtimeServer } from './http.js';
+
+function timeoutError(label, timeoutMs) {
+  return new CliError(`${label} timed out after ${Math.ceil(timeoutMs / 1000)} seconds.`);
+}
+
+function socketPath(server) {
+  const base = server.pathname.replace(/\/$/, '');
+  return `${base}/socket.io`.replace(/^\/\//, '/');
+}
+
+export async function connectRealtime(jar, noteId, timeoutMs = 15_000) {
+  const { server } = await realtimeServer(jar, noteId);
+  const cookie = jar.header(server);
+  const socket = io(server.origin, {
+    autoConnect: false,
+    path: socketPath(server),
+    query: { noteId },
+    timeout: Math.min(timeoutMs, 5_000),
+    reconnection: false,
+    transports: ['websocket', 'polling'],
+    // Node's Engine.IO cookie jar would append an empty lowercase cookie
+    // header and shadow the authenticated header supplied below.
+    withCredentials: false,
+    extraHeaders: {
+      ...(cookie ? { Cookie: cookie } : {}),
+      Origin: BASE_URL,
+      Referer: `${BASE_URL}/${encodeURIComponent(noteId)}`,
+      'User-Agent': 'hackmd-rt/2.0'
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(timeoutError('Realtime document handshake', timeoutMs));
+    }, timeoutMs);
+    const fail = (error) => {
+      clearTimeout(timer);
+      socket.close();
+      reject(error instanceof CliError ? error : new CliError(`Realtime connection failed: ${error.message}`));
+    };
+    socket.once('connect_error', fail);
+    socket.once('info', (info) => fail(new CliError(`HackMD realtime rejected the note (code ${info?.code || 'unknown'}).`, 3)));
+    socket.once('doc', (doc) => {
+      clearTimeout(timer);
+      socket.off('connect_error', fail);
+      if (!doc || typeof doc.str !== 'string' || !Number.isInteger(doc.revision)) {
+        socket.close();
+        reject(new CliError('HackMD realtime returned an invalid document snapshot.'));
+        return;
+      }
+      resolve({ socket, content: doc.str, revision: doc.revision, clients: doc.clients || {} });
+    });
+    socket.connect();
+  });
+}
+
+export async function readRealtime(jar, noteId, timeoutMs) {
+  const connection = await connectRealtime(jar, noteId, timeoutMs);
+  connection.socket.close();
+  return { content: connection.content, revision: connection.revision, clients: connection.clients };
+}
+
+export async function writeRealtime(jar, noteId, operation, timeoutMs = 20_000) {
+  const connection = await connectRealtime(jar, noteId, timeoutMs);
+  const { socket, revision, content } = connection;
+  const json = operation(content).toJSON();
+  if (json.length === 0 || (json.length === 1 && json[0] === content.length)) {
+    socket.close();
+    return { changed: false, revision, concurrent: false };
+  }
+
+  return new Promise((resolve, reject) => {
+    let concurrent = false;
+    const timer = setTimeout(() => {
+      const error = new CliError(
+        `Realtime operation acknowledgement timed out after ${Math.ceil(timeoutMs / 1000)} seconds.`,
+        5,
+        { mayHaveApplied: true, noteId, baseRevision: revision }
+      );
+      cleanup();
+      reject(error);
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.removeAllListeners('ack');
+      socket.removeAllListeners('operation');
+      socket.removeAllListeners('info');
+      socket.removeAllListeners('disconnect');
+      socket.close();
+    };
+    socket.on('operation', () => { concurrent = true; });
+    socket.once('info', (info) => {
+      cleanup();
+      reject(new CliError(`HackMD rejected the operation (code ${info?.code || 'unknown'}).`, 3));
+    });
+    socket.once('disconnect', (reason) => {
+      cleanup();
+      reject(new CliError(
+        `Realtime disconnected before acknowledgement (${reason}).`,
+        5,
+        { mayHaveApplied: true, noteId, baseRevision: revision }
+      ));
+    });
+    socket.once('ack', (nextRevision) => {
+      cleanup();
+      if (!Number.isInteger(nextRevision) || nextRevision <= revision) {
+        reject(new CliError('HackMD acknowledged the operation with an invalid revision.'));
+        return;
+      }
+      resolve({ changed: true, revision: nextRevision, concurrent });
+    });
+    socket.emit('operation', revision, json, null);
+  });
+}

--- a/SKILLS/hackmd-realtime-crud/test/cli.test.js
+++ b/SKILLS/hackmd-realtime-crud/test/cli.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseCommandLine, validateInvocation } from '../src/cli.js';
+
+test('parses values and boolean options', () => {
+  assert.deepEqual(parseCommandLine(['notes', 'get', 'id', '--timeout', '5000', '--json']), {
+    options: { timeout: '5000', json: true },
+    positionals: ['notes', 'get', 'id']
+  });
+});
+
+test('rejects unknown and incompatible options', () => {
+  assert.throws(
+    () => validateInvocation(['notes', 'get', 'id'], { surprise: true }),
+    /Unknown option/
+  );
+  assert.throws(
+    () => validateInvocation(['notes', 'get', 'id'], { raw: true, json: true }),
+    /cannot be used together/
+  );
+});
+
+test('validates positional arity and numeric options', () => {
+  assert.throws(() => validateInvocation(['notes', 'get'], {}), /exactly one selector/);
+  assert.throws(() => validateInvocation(['notes', 'list', 'extra'], {}), /does not accept/);
+  assert.throws(() => validateInvocation(['notes', 'search', 'query'], { limit: 'wat' }), /positive integer/);
+  assert.throws(() => validateInvocation(['notes', 'search', 'query'], { limit: '-1' }), /positive integer/);
+});

--- a/SKILLS/hackmd-realtime-crud/test/cookies.test.js
+++ b/SKILLS/hackmd-realtime-crud/test/cookies.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { CookieJar, importCookies, normalizeCookieExport } from '../src/cookies.js';
+
+test('normalizes browser cookies and rejects unrelated domains', () => {
+  const result = normalizeCookieExport([
+    { name: 'connect.sid', value: 'signed', domain: '.hackmd.io', path: '/', secure: true, httpOnly: true },
+    { name: 'foreign', value: 'secret', domain: '.example.com', path: '/' }
+  ]);
+  assert.equal(result.cookies.length, 1);
+  assert.equal(result.skipped, 1);
+  assert.equal(result.cookies[0].domain, 'hackmd.io');
+  assert.equal(result.cookies[0].hostOnly, false);
+});
+
+test('cookie header obeys path, secure, and expiration constraints', () => {
+  const jar = new CookieJar([
+    { name: 'valid', value: 'one', domain: 'hackmd.io', path: '/', secure: true },
+    { name: 'path', value: 'two', domain: 'hackmd.io', path: '/private', secure: true },
+    { name: 'domain', value: 'four', domain: '.hackmd.io', path: '/', secure: true },
+    { name: 'expired', value: 'three', domain: 'hackmd.io', path: '/', expires: 1 }
+  ]);
+  assert.equal(jar.header('https://hackmd.io/note'), 'valid=one; domain=four');
+  assert.equal(jar.header('https://hackmd.io/private/note'), 'path=two; valid=one; domain=four');
+  assert.equal(jar.header('https://hackmd.io/private-other'), 'valid=one; domain=four');
+  assert.equal(jar.header('https://realtime.hackmd.io/note'), 'domain=four');
+  assert.equal(jar.header('http://hackmd.io/private/note'), '');
+});
+
+test('orders same-name cookies by longest path first', () => {
+  const jar = new CookieJar([
+    { name: 'sid', value: 'root', domain: 'hackmd.io', path: '/', secure: true },
+    { name: 'sid', value: 'specific', domain: 'hackmd.io', path: '/private', secure: true }
+  ]);
+  assert.equal(jar.header('https://hackmd.io/private/note'), 'sid=specific; sid=root');
+});
+
+test('import writes a private cookie store without printing values', async () => {
+  const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hackmd-rt-test-'));
+  const source = path.join(directory, 'export.json');
+  const destination = path.join(directory, 'cookies.json');
+  await fs.promises.writeFile(source, JSON.stringify([
+    { name: 'connect.sid', value: 'signed', domain: 'hackmd.io', path: '/', secure: true }
+  ]));
+  const result = await importCookies(source, destination, true);
+  assert.deepEqual(result, { imported: 1, skipped: 0, path: destination });
+  assert.equal((await fs.promises.stat(destination)).mode & 0o777, 0o600);
+});

--- a/SKILLS/hackmd-realtime-crud/test/http.test.js
+++ b/SKILLS/hackmd-realtime-crud/test/http.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { csrfFromNewPage } from '../src/http.js';
+
+test('extracts the CSRF token from the current new-note bootstrap', () => {
+  assert.equal(csrfFromNewPage("<script>xhr.send('_csrf=token-123');</script>"), 'token-123');
+});
+
+test('fails closed when the new-note bootstrap changes', () => {
+  assert.throws(() => csrfFromNewPage('<script>submit()</script>'), /no longer exposes/);
+});

--- a/SKILLS/hackmd-realtime-crud/test/notes.test.js
+++ b/SKILLS/hackmd-realtime-crud/test/notes.test.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveNote, searchNotes, selectorFromInput, updateById } from '../src/notes.js';
+import { CliError } from '../src/errors.js';
+
+const notes = [
+  { id: 'uuid-1', shortId: 'short-1', title: 'Alpha', tags: ['one'], content: 'excerpt', teamname: null },
+  { id: 'uuid-2', shortId: 'short-2', title: 'Beta', tags: ['two'], content: 'needle here', teamname: 'team' }
+];
+
+test('normalizes HackMD URLs without accepting foreign URLs', () => {
+  assert.equal(selectorFromInput('https://hackmd.io/short-1'), 'short-1');
+  assert.equal(selectorFromInput('https://example.com/short-1'), 'https://example.com/short-1');
+});
+
+test('resolves exact title and ID selectors', () => {
+  assert.equal(resolveNote(notes, 'Alpha').id, 'uuid-1');
+  assert.equal(resolveNote(notes, 'short-2').id, 'uuid-2');
+});
+
+test('rejects duplicate exact titles', () => {
+  assert.throws(() => resolveNote([...notes, { ...notes[0], id: 'uuid-3' }], 'Alpha'), /Ambiguous/);
+});
+
+test('searches overview metadata and excerpts', () => {
+  assert.deepEqual(searchNotes(notes, 'needle').map((note) => note.id), ['uuid-2']);
+  assert.deepEqual(searchNotes(notes, 'one').map((note) => note.id), ['uuid-1']);
+});
+
+test('reconciles a lost acknowledgement through exact readback', async () => {
+  const realtime = {
+    write: async () => {
+      throw new CliError('ack lost', 5, { mayHaveApplied: true });
+    },
+    read: async () => ({ content: '# requested', revision: 4 })
+  };
+  assert.deepEqual(await updateById({}, 'note-id', '# requested', 1_000, realtime), {
+    changed: true,
+    concurrent: false,
+    revision: 4,
+    verified: true,
+    acknowledgementLost: true
+  });
+});
+
+test('reports an uncertain update when acknowledgement and content disagree', async () => {
+  const realtime = {
+    write: async () => {
+      throw new CliError('ack lost', 5, { mayHaveApplied: true });
+    },
+    read: async () => ({ content: '# concurrent', revision: 4 })
+  };
+  await assert.rejects(
+    updateById({}, 'note-id', '# requested', 1_000, realtime),
+    (error) => error.exitCode === 5 && error.details.mayHaveApplied === true
+  );
+});

--- a/SKILLS/hackmd-realtime-crud/test/ot.test.js
+++ b/SKILLS/hackmd-realtime-crud/test/ot.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { applyOperation, replacementOperation, transformOperations } from '../src/ot.js';
+
+test('builds a minimal replacement operation', () => {
+  const operation = replacementOperation('abcde', 'abXYde');
+  assert.deepEqual(operation.toJSON(), [2, 'XY', -1, 2]);
+  assert.equal(operation.apply('abcde'), 'abXYde');
+});
+
+test('uses UTF-16 code-unit lengths for supplementary characters', () => {
+  const before = 'a🌸b';
+  const after = 'a🌸中文b';
+  const operation = replacementOperation(before, after);
+  assert.equal(operation.apply(before), after);
+  assert.equal(operation.baseLength, before.length);
+});
+
+test('applies and transforms serialized concurrent operations', () => {
+  assert.equal(applyOperation('abc', [1, 'x', 2]), 'axbc');
+  const [left, right] = transformOperations([1, 'x', 2], [2, 'y', 1]);
+  assert.equal(applyOperation(applyOperation('abc', [1, 'x', 2]), right), 'axbyc');
+  assert.equal(applyOperation(applyOperation('abc', [2, 'y', 1]), left), 'axbyc');
+});


### PR DESCRIPTION
## Summary

- add `hackmd-rt` v2 using HackMD realtime Socket.IO + `@hackmd/ot`
- replace editor DOM automation with cookie-authenticated OT reads and mutations
- verify every update through independent realtime reconnect and exact Markdown readback
- classify uncertain create/update/delete outcomes so agents do not replay mutations blindly
- include agent skill instructions and 18 unit tests

## Production verification

Verified against HackMD production on 2026-08-21 with disposable notes:

- realtime registration and `doc` handshake
- exact Markdown read
- create followed by OT content initialization
- update with Traditional Chinese and emoji
- `ack` revision advance and byte-identical reconnect readback

Delete was not live-tested because the disposable session was anonymous and did not own a deletable authenticated note.

## Checks

- `npm run check`
- `npm audit --omit=dev`
- `npm pack --dry-run`
- install from generated tarball and run `hackmd-rt --version` / `--help`